### PR TITLE
Be more consistent with extent/bounds for MapPanels

### DIFF
--- a/lib/GXM/widgets/MapPanel.js
+++ b/lib/GXM/widgets/MapPanel.js
@@ -95,14 +95,13 @@ GXM.MapPanel = Ext.extend(Ext.Component, {
      */
     zoom: null,
     
-    /** api: config[bounds]
+    /** api: config[extent]
      * 
      *  ``OpenLayers.Bounds or Array(Number)``  An initial extent for the map 
      *  (used if center and zoom are not provided.  If an array, the first four 
      *  items should be minx, miny, maxx, maxy.
      */
-    bounds: null,
-    //TODO: we should align this to GeoExt's extent, shouldn't we?
+    extent: null,
     
     /** api: config[fullscreen]
      * 
@@ -197,7 +196,7 @@ GXM.MapPanel = Ext.extend(Ext.Component, {
             me.center = new OpenLayers.LonLat(me.center[0], me.center[1]); 
         } 
         
-        // check config-property bounds
+        // check config-property extent
         if ( Ext.isString(me.extent) ) {
             me.extent = OpenLayers.Bounds.fromString(me.extent);
         } else if(Ext.isArray(me.extent)) {


### PR DESCRIPTION
The property 'extent' is then in sync with GeoExts 'extent'.
