### PR TITLE
Added explicit setting of the config-options mapCenter and mapExtent

### DIFF
--- a/src/GXM/Map.js
+++ b/src/GXM/Map.js
@@ -100,7 +100,7 @@ Ext.define('GXM.Map', {
     controls: null,
     
     config: {
-    	
+        
         /** api: config[map]
          * 
          *  ``OpenLayers.Map or Object``  A configured map or a configuration object
@@ -142,6 +142,14 @@ Ext.define('GXM.Map', {
         if (config.map instanceof OpenLayers.Map) {
             this._map = config.map;
             delete config.map;
+        }
+        if (config.mapCenter instanceof OpenLayers.LonLat) {
+            this._mapCenter = config.mapCenter;
+            delete config.mapCenter;
+        }
+        if (config.mapExtent instanceof OpenLayers.Bounds) {
+            this._mapExtent = config.mapExtent;
+            delete config.mapExtent;
         }
         
         this.callParent(arguments);


### PR DESCRIPTION
When mapCenter and mapExtent are passed as objects, we get problems due to a known issue with circular references. By certain settings within constructor this can be solved.

This was detected by failing tests, as described in #28
The two related tests pass now.
