### PR TITLE
Make the LayerList test_basic() more robust.

### DIFF
--- a/src/GXM/LayerList.js
+++ b/src/GXM/LayerList.js
@@ -37,6 +37,7 @@ Ext.define('GXM.LayerList', {
     
     requires: [
         'GXM.version',
+        'GXM.util.Base',
         'GXM.data.LayerStore'
     ],
    

--- a/tests/lib/widgets/LayerList.test.html
+++ b/tests/lib/widgets/LayerList.test.html
@@ -121,15 +121,35 @@ function test_basics(t) {
                 // Does the store have the correct model?
                 t.eq(store.getModel().modelName, 'GXM.data.LayerModel', 'Layerpanel.store works on the GXM.data.LayerModel');
                 
-                var firstOrLast;
-                if(!Ext.isEmpty(mappanel.layers.getSorters()) && mappanel.layers.getSorters()[0].direction === "DESC") {
-                // compairing the managed layers by id:
-                    firstOrLast = 'last'; 
+                var hasSorter = (!Ext.isEmpty(store.getSorters())),
+                    sortDir = (hasSorter && store.getSorters()[0].getDirection() === "DESC") ? 'DESC' : 'ASC',
+                    minZIndex = Number.POSITIVE_INFINITY,
+                    maxZIndex =  Number.NEGATIVE_INFINITY,
+                    currentZIndex;
+                Ext.each(mappanel.getMap().layers, function(l){
+                    currentZIndex = l.getZIndex();
+                    if (currentZIndex <= minZIndex) {
+                        minZIndex = currentZIndex;
+                    }
+                    if (currentZIndex >= maxZIndex) {
+                        maxZIndex = currentZIndex;
+                    }
+                });
+
+                if(sortDir === "DESC") {
+                    expectedZIndexOfFirstRecord = maxZIndex; 
                 } else {
-                    firstOrLast = 'first';
+                    expectedZIndexOfFirstRecord = minZIndex;
                 }
                 
-                t.eq(store[firstOrLast]().getLayer().id, mappanel.getMap().layers[0].id, 'managed entities are the same');
+                t.eq(
+                    mappanel.layers.first().getLayer().getZIndex(),
+                    expectedZIndexOfFirstRecord,
+                    'Managed entities are the same (First record with #' 
+                        + mappanel.layers.first().getLayer().id 
+                        + ' has the ' + (sortDir === 'ASC' ? 'lowest' : 'highest')
+                        + ' z-index and sort direction is "' + sortDir + '")'
+                );
                 
                 // check the generated HTML:
                 var elem = layerpanel.innerElement.dom;


### PR DESCRIPTION
Instead of taking the first layer of the OpenLayers.Map and compair it to the
first/last record of the GXM.Map's layerstore, we first find the maximum and
minimum z-indeces of the OPenLayers.Map and use this to compair with the first
or last (depending on sort direction) records z-index.

This way the test passes with current HEAD and with commit b8f710f151af165e382eed6c0c6ba27c39f7aa0d applied.

See also #31; if this and the commits from #31 get merged, all tests pass.
