### PR TITLE
Testsuite

### DIFF
--- a/src/GXM/LayerList.js
+++ b/src/GXM/LayerList.js
@@ -242,7 +242,7 @@ Ext.define('GXM.LayerList', {
      * state of layers managed by the list.
      * @param {Ext.EventObject} evt The event-object 
      */
-    onChangeLayer: function(evt){
+    onChangeLayer: function(evt) {
         this.refresh();
     },
     

--- a/tests/lib/Button.test.html
+++ b/tests/lib/Button.test.html
@@ -8,24 +8,27 @@
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
         
-        <!-- load test helper functions -->
-        <script type="text/javascript" src="../helperfunctions.js"></script>     
-
+        <!-- 
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
         <script type="text/javascript">
+        window.LOAD_GXM = [
+            "../../src/GXM/version.js",
+            "../../src/GXM/util/Base.js",
+            "../../src/GXM/Button.js",
+            "../../src/GXM/data/LayerModel.js",
+            "../../src/GXM/data/LayerStore.js",
+            "../../src/GXM/Map.js"
+        ];
+        </script>
+        <script type="text/javascript" src="../gxm.scriptloader.js"></script>
         
-        Ext.Loader.setConfig({
-            enabled: true,
-            disableCaching: false,
-            paths: {
-                GXM: "../../src/GXM",
-                Ext: "http://cdn.sencha.io/touch/sencha-touch-2.0.1/src"
-            }
-        });
+        <!-- load test helper functions -->
+        <script type="text/javascript" src="../helperfunctions.js"></script>
+        
+        <script type="text/javascript">
 
-        Ext.require([
-            'GXM.Button'
-        ]);
-        
 var recordedEventData = {
     test_activateControlCalled: { 
         checkpoints: [], 
@@ -248,6 +251,13 @@ function test_triggerControlCalled(t){
     
     var expectedBtnClicks = ['zoomIn', 'zoomOut'];
     t.plan(expectedBtnClicks.length * 2);
+    
+    if (!canOpenWindow()) {
+        t.plan(0);
+        t.debug_print("skipping this test as we aren't able to load a window.");
+        return;
+    }
+    
     
     t.open_window('./winopen/button-test-window.html', function(wnd){
         // grab recorded events

--- a/tests/lib/FeatureList.test.html
+++ b/tests/lib/FeatureList.test.html
@@ -31,19 +31,6 @@
         
         <script type="text/javascript">
         
-Ext.Loader.setConfig({
-    enabled: true,
-    disableCaching: false,
-    paths: {
-        GXM: "../../src/GXM",
-        Ext: "http://cdn.sencha.io/touch/sencha-touch-2.0.1/src"
-    }
-});
-
-Ext.require([
-    'GXM.FeatureList',
-    'GXM.Map'
-]);
 
 function getMapPanel() {
     var map = new OpenLayers.Map({

--- a/tests/lib/FeatureList.test.html
+++ b/tests/lib/FeatureList.test.html
@@ -8,6 +8,21 @@
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
         
+        <!-- 
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
+        <script type="text/javascript">
+        window.LOAD_GXM = [
+            "../../src/GXM/version.js",
+            "../../src/GXM/util/Base.js",
+            "../../src/GXM/data/LayerModel.js",
+            "../../src/GXM/data/LayerStore.js",
+            "../../src/GXM/Map.js"
+        ];
+        </script>
+        <script type="text/javascript" src="../gxm.scriptloader.js"></script>
+        
         <!-- load test helper functions -->
         <script type="text/javascript" src="../helperfunctions.js"></script>
         

--- a/tests/lib/FeatureList.test.html
+++ b/tests/lib/FeatureList.test.html
@@ -18,6 +18,9 @@
             "../../src/GXM/util/Base.js",
             "../../src/GXM/data/LayerModel.js",
             "../../src/GXM/data/LayerStore.js",
+            "../../src/GXM/data/FeatureModel.js",
+            "../../src/GXM/data/FeatureStore.js",
+            "../../src/GXM/FeatureList.js",
             "../../src/GXM/Map.js"
         ];
         </script>

--- a/tests/lib/FeaturePopup.test.html
+++ b/tests/lib/FeaturePopup.test.html
@@ -8,25 +8,24 @@
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
         
+        <!-- 
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
+        <script type="text/javascript">
+        window.LOAD_GXM = [
+            "../../src/GXM/version.js",
+            "../../src/GXM/util/Base.js",
+            "../../src/GXM/FeaturePopup.js"
+        ];
+        </script>
+        <script type="text/javascript" src="../gxm.scriptloader.js"></script>
+        
         <!-- load test helper functions -->
         <script type="text/javascript" src="../helperfunctions.js"></script>
         
         <script type="text/javascript">
         
-Ext.Loader.setConfig({
-    enabled: true,
-    disableCaching: false,
-    paths: {
-        GXM: "../../src/GXM",
-        Ext: "http://cdn.sencha.io/touch/sencha-touch-2.0.1/src"
-    }
-});
-
-Ext.require([
-    'GXM.FeaturePopup',
-    'GXM.Map'
-]);
-
 function getFeaturePopup(feature, useCustomTpl) {
     
     var popup = null;

--- a/tests/lib/FeatureRenderer.test.html
+++ b/tests/lib/FeatureRenderer.test.html
@@ -7,21 +7,24 @@
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
         
-        <!-- Setup the GXM loader -->
+        <!-- 
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
         <script type="text/javascript">
-        Ext.Loader.setConfig({
-            enabled: true,
-            disableCaching: false,
-            paths: {
-                GXM: "../../src/GXM",
-                Ext: "http://cdn.sencha.io/touch/sencha-touch-2.0.1/src"
-            }
-        });
-
-        Ext.require([
-            'GXM.FeatureRenderer'
-        ]);
-
+        window.LOAD_GXM = [
+            "../../src/GXM/version.js",
+            "../../src/GXM/util/Base.js",
+            "../../src/GXM/FeatureRenderer.js"
+        ];
+        </script>
+        <script type="text/javascript" src="../gxm.scriptloader.js"></script>
+        
+        <!-- load test helper functions -->
+        <script type="text/javascript" src="../helperfunctions.js"></script>
+        
+        <script type="text/javascript">
+        
         function test_initialize(t) {
 
             t.plan(3);

--- a/tests/lib/LayerList.test.html
+++ b/tests/lib/LayerList.test.html
@@ -8,24 +8,27 @@
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
         
+        <!-- 
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
+        <script type="text/javascript">
+        window.LOAD_GXM = [
+            "../../src/GXM/version.js",
+            "../../src/GXM/util/Base.js",
+            "../../src/GXM/data/LayerModel.js",
+            "../../src/GXM/data/LayerStore.js",
+            "../../src/GXM/LayerList.js",
+            "../../src/GXM/Map.js"
+        ];
+        </script>
+        <script type="text/javascript" src="../gxm.scriptloader.js"></script>
+        
         <!-- load test helper functions -->
         <script type="text/javascript" src="../helperfunctions.js"></script>
         
         <script type="text/javascript">
         
-Ext.Loader.setConfig({
-    enabled: true,
-    disableCaching: false,
-    paths: {
-        GXM: "../../src/GXM",
-        Ext: "http://cdn.sencha.io/touch/sencha-touch-2.0.1/src"
-    }
-});
-
-Ext.require([
-    'GXM.LayerList',
-    'GXM.Map'
-])
         
 // can be copied to other testfiles, simply adjust the first variables  
 function test_definition(t) {
@@ -378,7 +381,7 @@ function test_destroy(t) {
                 
                 // keep this formatting due to toString() comparison
                 //TODO implement a better comparison
-                var onChangeLayerFunc = "function (evt){\n" +
+                var onChangeLayerFunc = "function (evt) {\n" +
                     "        this.refresh();\n" +
                     "    }";
                 var onAddLayerFunc = "function (evt) {\n" +

--- a/tests/lib/data/FeatureModel.test.html
+++ b/tests/lib/data/FeatureModel.test.html
@@ -7,21 +7,22 @@
         
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
-        
-        <!-- Setup the GXM loader -->
+                
+        <!--
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
         <script type="text/javascript">
-        Ext.Loader.setConfig({
-            enabled: true,
-            disableCaching: false,
-            paths: {
-                GXM: "../../../src/GXM",
-                Ext: "http://cdn.sencha.io/touch/sencha-touch-2.0.1/src"
-            }
-        });
-        Ext.require(
-            "GXM.data.FeatureModel"
-        );
+        window.LOAD_GXM = [
+            "../../../src/GXM/version.js",
+            "../../../src/GXM/util/Base.js",
+            "../../../src/GXM/data/FeatureModel.js"
+        ];
         </script>
+        <script type="text/javascript" src="../../gxm.scriptloader.js"></script>
+        
+        <!-- load test helper functions -->
+        <script type="text/javascript" src="../../helperfunctions.js"></script>
         
         <script type="text/javascript">
 

--- a/tests/lib/data/FeatureStore.test.html
+++ b/tests/lib/data/FeatureStore.test.html
@@ -10,20 +10,22 @@
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
         
-        <!-- Setup the GXM loader -->
+        <!--
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
         <script type="text/javascript">
-        Ext.Loader.setConfig({
-            enabled: true,
-            disableCaching: false,
-            paths: {
-                GXM: "../../../src/GXM",
-                Ext: "http://cdn.sencha.io/touch/sencha-touch-2.0.1/src"
-            }
-        });
-        Ext.require([
-            'GXM.data.FeatureStore',
-        ]);
+        window.LOAD_GXM = [
+            "../../../src/GXM/version.js",
+            "../../../src/GXM/util/Base.js",
+            "../../../src/GXM/data/FeatureModel.js",
+            "../../../src/GXM/data/FeatureStore.js"
+        ];
         </script>
+        <script type="text/javascript" src="../../gxm.scriptloader.js"></script>
+        
+        <!-- load test helper functions -->
+        <script type="text/javascript" src="../../helperfunctions.js"></script>
         
         <script type="text/javascript">
 

--- a/tests/lib/data/LayerModel.test.html
+++ b/tests/lib/data/LayerModel.test.html
@@ -8,21 +8,21 @@
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
         
-        <!-- Setup the GXM loader -->
+        <!--
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
         <script type="text/javascript">
-        Ext.Loader.setConfig({
-            enabled: true,
-            disableCaching: false,
-            paths: {
-                GXM: "../../../src/GXM",
-                Ext: "http://cdn.sencha.io/touch/sencha-touch-2.0.1/src"
-            }
-        });
-        Ext.require(
-            "GXM.data.LayerModel", 
-            "GXM.Map"
-        );
+        window.LOAD_GXM = [
+            "../../../src/GXM/version.js",
+            "../../../src/GXM/util/Base.js",
+            "../../../src/GXM/data/LayerModel.js"
+        ];
         </script>
+        <script type="text/javascript" src="../../gxm.scriptloader.js"></script>
+        
+        <!-- load test helper functions -->
+        <script type="text/javascript" src="../../helperfunctions.js"></script>
         
         <script type="text/javascript">
 

--- a/tests/lib/data/LayerStore.test.html
+++ b/tests/lib/data/LayerStore.test.html
@@ -10,21 +10,22 @@
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
         
-        <!-- Setup the GXM loader -->
+        <!--
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
         <script type="text/javascript">
-        Ext.Loader.setConfig({
-            enabled: true,
-            disableCaching: false,
-            paths: {
-                GXM: "../../../src/GXM",
-                Ext: "http://cdn.sencha.io/touch/sencha-touch-2.0.1/src"
-            }
-        });
-        Ext.require([
-            'GXM.data.LayerStore',
-            'GXM.Map'
-        ]);
+        window.LOAD_GXM = [
+            "../../../src/GXM/version.js",
+            "../../../src/GXM/util/Base.js",
+            "../../../src/GXM/data/LayerModel.js",
+            "../../../src/GXM/data/LayerStore.js"
+        ];
         </script>
+        <script type="text/javascript" src="../../gxm.scriptloader.js"></script>
+        
+        <!-- load test helper functions -->
+        <script type="text/javascript" src="../../helperfunctions.js"></script>
         
         <script type="text/javascript">
 


### PR DESCRIPTION
- Instead of using the Ext.loader-mechanism, we use a very simple script-loader, which also works in e.g. the iPad and on iOs-Phones.
- Included a exception for windows on iPad and iOs-Phones.
