### PR TITLE
Made the remove event of a layer within the map panel more robust.

### DIFF
--- a/src/GXM/Map.js
+++ b/src/GXM/Map.js
@@ -411,7 +411,9 @@ Ext.define('GXM.Map', {
     onRemovelayer: function (olEvt) {
         var layer = olEvt.layer;
         var record = this.layers.findRecord('id', layer.id);
-        this.layers.remove(record);
+        if(record) {
+            this.layers.remove(record);
+        }
         this.fireEvent("afterlayerremove");
     },
 


### PR DESCRIPTION
I added an additional check on the queried record. In some cases I ran into the problem that the record was not inside the store and so the handler would crash.
