### PR TITLE
implement a feature editor

### DIFF
--- a/examples/data/wfsdescribefeaturetype.xml
+++ b/examples/data/wfsdescribefeaturetype.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:asbuilt="http://www.sfmta.com/" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.sfmta.com/">
+  <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://localhost:80/geoserver/schemas/gml/3.1.1/base/gml.xsd"/>
+  <xsd:complexType name="DOCSType">
+    <xsd:complexContent>
+      <xsd:extension base="gml:AbstractFeatureType">
+        <xsd:sequence>
+          <xsd:element maxOccurs="1" minOccurs="0" name="FILETYPE" nillable="true" type="xsd:string">
+            <xsd:annotation>
+              <xsd:appinfo>{"title":{"en":"File type"}}</xsd:appinfo>
+              <xsd:documentation xml:lang="en">
+                  The file type of the document
+              </xsd:documentation>
+             </xsd:annotation>
+          </xsd:element>
+          <xsd:element maxOccurs="1" minOccurs="0" name="SAMP_POP" nillable="true">
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:double">
+                <xsd:maxInclusive value="10"/>
+                <xsd:minInclusive value="5"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:element>
+          <xsd:element maxOccurs="1" minOccurs="0" name="DDRAWDATE" nillable="true" type="xsd:date"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="GEOM" nillable="true" type="gml:PointPropertyType"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="HEIGHT" nillable="true" type="xsd:decimal"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="MEMO" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="STATE_NAME" nillable="false">
+             <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                <xsd:maxLength value="10"/>
+                <xsd:minLength value="5"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:element>
+          <xsd:element name="DRINK_NAME" minOccurs="0" nillable="true">
+            <xsd:simpleType>
+              <xsd:restriction base="xs:string">
+                <xsd:enumeration value="pop"/>
+                <xsd:enumeration value="soda"/>
+                <xsd:enumeration value="other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:element>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="DOCS" substitutionGroup="gml:_Feature" type="asbuilt:DOCSType"/>
+</xsd:schema>

--- a/examples/data/wfsdescribefeaturetype.xml
+++ b/examples/data/wfsdescribefeaturetype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:asbuilt="http://www.sfmta.com/" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.sfmta.com/">
+<xsd:schema xmlns:foo="http://www.foo.com/" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.foo.com/">
   <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://localhost:80/geoserver/schemas/gml/3.1.1/base/gml.xsd"/>
   <xsd:complexType name="DOCSType">
     <xsd:complexContent>
@@ -46,5 +46,5 @@
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
-  <xsd:element name="DOCS" substitutionGroup="gml:_Feature" type="asbuilt:DOCSType"/>
+  <xsd:element name="DOCS" substitutionGroup="gml:_Feature" type="foo:DOCSType"/>
 </xsd:schema>

--- a/examples/example-utility.js
+++ b/examples/example-utility.js
@@ -243,6 +243,17 @@ example.utility = {
                 lines.push(ind + '}]');
                 lines.push('});');
                 break;
+
+            case 'featureeditor':
+                lines.push(comS + '// create a featureeditor with a feature and attribute store' + comE);
+                lines.push(varCode + ' editor = ' + extCreateCode + 'GXM.form.FeatureEditor\', {');
+                lines.push(ind + 'width: 400, ');
+                lines.push(ind + 'height: 400, ');
+                lines.push(ind + 'centered: true, ');
+                lines.push(ind + 'feature: feature, ');
+                lines.push(ind + 'schema: store');
+                lines.push('});');
+                break;
                 
             default:
                 lines.push(comS + '// No documentation for "' + exampleKey + '"' + comE);

--- a/examples/featureeditor.html
+++ b/examples/featureeditor.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        
+        <title>GXM: The GXM.form.FeatureEditor-class</title>
+        
+        <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        
+        <!-- The CSS of Sencha Touch and GXM -->
+        <link rel="stylesheet" href="http://cdn.sencha.io/touch/sencha-touch-2.0.1/resources/css/sencha-touch.css" type="text/css">
+        <link rel="stylesheet" href="http://openlayers.org/api/2.11/theme/default/style.tidy.css" type="text/css">
+        <link rel="stylesheet" href="../resources/css/gxm.css" type="text/css">
+        <link rel="stylesheet" href="./examples.css" type="text/css">
+        
+        <!-- Load Sencha Touch -->
+        <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all.js"></script>
+        <!-- Load OpenLayers -->
+        <!-- You should definitely consider using a custom single-file version of OpenLayers -->
+        <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
+        
+        <!-- This file loads all relevant files -->
+        <script type="text/javascript" src="../src/GXM.loader.js"></script>
+        <script type="text/javascript" src="./example-utility.js"></script>
+        <script type="text/javascript" src="./featureeditor.js"></script>
+    </head>
+    <body>
+    </body>
+</html>

--- a/examples/featureeditor.js
+++ b/examples/featureeditor.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2012 The Open Source Geospatial Foundation
+ *
+ * Published under the BSD license.
+ *
+ * See http://svn.geoext.org/sandbox/gxm/geoext/gxm/license.txt for the full
+ * text of the license.
+ */
+
+/** api: example[featureeditor]
+ *  FeatureList and FeatureEditor interaction
+ *  ----------------
+ *  This example shows the use of the GXM.FeatureList-class in combination
+ *  with the GXM.FeatureEditor-class to generate a form to edit the feature's
+ *  attributes  when tapping on a list entry.
+ */
+
+Ext.require([
+    'GXM.FeatureList',
+    'GXM.form.FeatureEditor'
+]);
+
+Ext.setup({
+    onReady : function() {
+        OpenLayers.Layer.Vector.prototype.renderers = ["SVG2", "VML", "Canvas"];
+
+        var projection4326 = new OpenLayers.Projection("EPSG:4326");
+        var projection900913 = new OpenLayers.Projection("EPSG:900913");
+        
+        // Create a vector layer for drawing features
+        var layerVector = new OpenLayers.Layer.Vector('Vector data', {
+            displayInLayerSwitcher : false,
+            styleMap : new OpenLayers.StyleMap({
+                label : '${r1} ${r2}',
+                strokeColor : '#ee7e00',
+                strokeWidth : 3,
+                strokeOpacity : 0.85,
+                fillColor : '#eed000',
+                fillOpacity : 0.8,
+                pointRadius : 7,
+                fontSize : "12px",
+                fontFamily : "sans-serif",
+                labelXOffset : "0",
+                labelYOffset : "-10"
+            })
+        });
+        
+        var feature,
+            features = [];
+
+        feature = new OpenLayers.Feature.Vector(null, {
+            FILETYPE: "MUNI",
+            SAMP_POP: 7,
+            DDRAWDATE: 1948,
+            HEIGHT: 728.7,
+            STATE_NAME :'my state',
+            DRINK_NAME: 'pop'
+        });
+        features.push(feature);
+        layerVector.addFeatures(features);
+
+        var store = Ext.create('GXM.data.AttributeStore', {
+            url: "data/wfsdescribefeaturetype.xml"
+        });
+        store.load();
+
+        // Create the GXM.FeatureList that also contains a listener dealing with
+        // tap events on a specific feature in the list triggering a GXM.FeaturePopup.
+        var featureList = {
+            xtype : 'gxm_featurelist',
+            layer : layerVector,
+            itemTpl: '{feature.attributes.FILETYPE}',
+            title : 'FeatureList',
+            listeners : {
+                itemtap : function(list, idx, target, record, e, eOpts) {
+                    var feature = record.getFeature();
+                    var popup = Ext.create("GXM.form.FeatureEditor", {
+                        width: 400,
+                        height: 400,
+                        centered: true,
+                        feature : feature,
+                        schema: store
+                    });
+                    Ext.Viewport.add(popup);
+                    popup.show();
+                }
+            }
+        };
+        
+        // A button to show relevant code parts
+        var btnSource = example.utility.getSourceCodeButton('featurepopup');
+        
+        // Create the viewport
+        var viewport = Ext.create('Ext.TabPanel', {
+            fullscreen : true,
+            items : [
+                featureList, 
+                {
+                    xtype : 'toolbar',
+                    docked : 'bottom',
+                    items : [
+                        {xtype : 'spacer'},
+                        btnSource
+                    ]
+                }
+            ]
+        });
+    }
+});

--- a/examples/featureeditor.js
+++ b/examples/featureeditor.js
@@ -56,6 +56,7 @@ Ext.setup({
             STATE_NAME :'my state',
             DRINK_NAME: 'pop'
         });
+        feature.fid = 'foo.1';
         features.push(feature);
         layerVector.addFeatures(features);
 
@@ -63,6 +64,14 @@ Ext.setup({
             url: "data/wfsdescribefeaturetype.xml"
         });
         store.load();
+
+        // dummy protocol
+        var protocol = new OpenLayers.Protocol.WFS({
+            version: '1.1.0',
+            url: '/dummy?',
+            featureType: 'DOCS',
+            featureNS: 'http://www.foo.com/'
+        });
 
         // Create the GXM.FeatureList that also contains a listener dealing with
         // tap events on a specific feature in the list triggering a GXM.FeaturePopup.
@@ -79,6 +88,7 @@ Ext.setup({
                         height: 400,
                         centered: true,
                         feature : feature,
+                        protocol: protocol,
                         schema: store
                     });
                     Ext.Viewport.add(popup);

--- a/examples/featureeditor.js
+++ b/examples/featureeditor.js
@@ -60,18 +60,16 @@ Ext.setup({
                         width: 400,
                         height: 400,
                         listeners: {
-                            "failure": function(editor, evtType, msg) {
-                                if (evtType === GXM.form.FeatureEditor.VALIDATIONFAILURE) {
-                                    Ext.Msg.show({
-                                        zIndex: 1000,
-                                        showAnimation: null,
-                                        hideAnimation: null,
-                                        message: msg,
-                                        buttons: [{text: 'OK'}],
-                                        promptConfig: false,
-                                        fn: function(){}
-                                    });
-                                }
+                            "failure": function(editor, msg) {
+                                Ext.Msg.show({
+                                    zIndex: 1000,
+                                    showAnimation: null,
+                                    hideAnimation: null,
+                                    message: msg,
+                                    buttons: [Ext.MessageBox.OK],
+                                    promptConfig: false,
+                                    fn: function(){}
+                                });
                             }
                         },
                         centered: true,

--- a/src/GXM/FeatureList.js
+++ b/src/GXM/FeatureList.js
@@ -122,6 +122,7 @@ Ext.define('GXM.FeatureList', {
 
             // bind OL events
             layer.events.on({
+                "featuremodified": this.onFeatureModified,
                 "featureadded": this.onFeatureAdded,
                 "featureremoved": this.onFeatureRemoved,
                 scope: this
@@ -151,6 +152,11 @@ Ext.define('GXM.FeatureList', {
 
 
         this.callParent();
+    },
+
+    onFeatureModified: function(evt) {
+        var rec = this.getStore().findRecord("id", evt.feature.id);
+        rec.set('feature', evt.feature);
     },
 
     /**
@@ -202,6 +208,7 @@ Ext.define('GXM.FeatureList', {
             layer.events.un({
                 "featureadded": this.onFeatureAdded,
                 "featureremoved": this.onFeatureRemoved,
+                "featuremodified": this.onFeatureModified,
                 scope: this
             });
         }

--- a/src/GXM/FeatureList.js
+++ b/src/GXM/FeatureList.js
@@ -154,6 +154,10 @@ Ext.define('GXM.FeatureList', {
         this.callParent();
     },
 
+    /**
+     *  @private
+     *  @param {Ext.EventObject} evt The event-object
+     */
     onFeatureModified: function(evt) {
         var rec = this.getStore().findRecord("id", evt.feature.id);
         rec.set('feature', evt.feature);
@@ -179,7 +183,6 @@ Ext.define('GXM.FeatureList', {
     /**
      *  @private
      *  @param {Ext.EventObject} evt The event-object
-     *  TODO events -featureadded, -featureremoved, double check: only when configured with layer!
      */
     onFeatureAdded: function (evt) {
         this.getStore().add(evt.feature);
@@ -188,7 +191,6 @@ Ext.define('GXM.FeatureList', {
     /**
      *  @private
      *  @param {Ext.EventObject} evt The event-object
-     *  TODO events -featureadded, -featureremoved, double check: only when configured with layer!
      */
     onFeatureRemoved: function (evt) {
         var store = this.getStore(),

--- a/src/GXM/form/FeatureEditor.js
+++ b/src/GXM/form/FeatureEditor.js
@@ -108,6 +108,21 @@ Ext.define("GXM.form.FeatureEditor",{
         var errors = me.validate();
         if (errors.isValid()) {
             var feature = me.getFeature();
+            if (!feature.modified) {
+                feature.modified = {
+                    attributes: {}
+                };
+            }
+            this.getFieldsAsArray().forEach(function(field) {
+                if (field.isDirty()) {
+                    var name = field.getName();
+                    feature.modified[name] = true;
+                    feature.attributes[name] = field.getValue();
+                }
+            });
+            if (feature.state !== OpenLayers.State.INSERT) {
+                feature.state = OpenLayers.State.UPDATE;
+            }
             if (feature.layer) {
                 feature.layer.events.triggerEvent('featuremodified', {
                     feature: feature
@@ -249,25 +264,6 @@ Ext.define("GXM.form.FeatureEditor",{
     },
     /**
      * @private
-     * Listener for the change event on the form fields. Updates the feature.
-     *
-     * @param {Ext.field.Text} this This field
-     * @param {Mixed} newValue The new value
-     * @param {Mixed} oldValue The original value
-     */
-    onFieldChange: function(field, newValue, oldValue) {
-        var feature = this.getFeature(), name = field.getName();
-        if (!feature.modified) {
-            feature.modified = {
-                attributes: {}
-            };
-        }
-        feature.modified.attributes[name] = true;
-        feature.attributes[name] = newValue;
-        feature.state = OpenLayers.State.UPDATE;
-    },
-    /**
-     * @private
      * create fieldConfig from a record from an AttributeStore. Also
      * create the config for the model to be used for validations.
      *
@@ -282,10 +278,6 @@ Ext.define("GXM.form.FeatureEditor",{
             return null;
         }
         var options = {};
-        options.listeners = {
-            'change': this.onFieldChange,
-            scope: this
-        };
         if (this.getReadOnly() === true) {
             options.readOnly = true;
         }

--- a/src/GXM/form/FeatureEditor.js
+++ b/src/GXM/form/FeatureEditor.js
@@ -1,0 +1,313 @@
+/*global Ext: true, OpenLayers: true, GXM: true */
+/*
+ * Copyright (c) 2012 The Open Source Geospatial Foundation
+ * 
+ * Published under the BSD license. 
+ * 
+ * See https://raw.github.com/geoext/GXM/master/license.txt for the full 
+ * text of the license.
+ */
+
+/* @requires GXM/version.js
+ */
+
+/**
+ * @class GXM.form.FeatureEditor
+ * The class that is used to construct a GXM FeatureEditor.
+ */
+Ext.define("GXM.form.FeatureEditor",{
+    extend: 'Ext.form.Panel',
+    alias: 'widget.gxm_featureeditor',
+    requires: [
+        'Ext.field.Text',
+        'Ext.field.Number',
+        'Ext.field.Checkbox',
+        'Ext.field.DatePicker',
+        'Ext.field.Select',
+        'Ext.data.Validations'
+    ],
+    config: {
+
+        /** @cfg {OpenLayers.Feature.Vector}
+         *  The feature being edited/displayed.
+         */
+        feature: null,
+
+        /** @cfg {Object}
+         *  An object with as keys the field names, which will provide the ability
+         *  to override the xtype that is created by default based on the
+         *  schema. 
+         */
+        fieldConfig: null,
+
+        /** @cfg {Array}
+         *  List of field config names corresponding to feature attributes.  If
+         *  not provided, fields will be derived from attributes. If provided,
+         *  the field order from this list will be used, and fields missing in the
+         *  list will be excluded.
+         */
+        formFields: null,
+
+        /** @cfg {Array}
+         *  Optional list of field names (case sensitive) that are to be
+         *  excluded from the form.
+         */
+        excludeFields: null,
+
+        /** @cfg {Boolean}
+         *  Set to true to disable editing. Default is false.
+         */
+        readOnly: null,
+
+        language: "en",
+
+        schema: null,
+
+        model: null,
+
+        protocol: null
+    },
+    statics: {
+        regexes: {
+            "text": new RegExp(
+                "^(text|string)$", "i"
+            ),
+            "number": new RegExp(
+                "^(number|float|decimal|double|int|long|integer|short)$", "i"
+            ),
+            "boolean": new RegExp(
+                "^(boolean)$", "i"
+            ),
+            "date": new RegExp(
+                "^(date|dateTime)$", "i"
+            )
+        }
+    },
+    doSave: function() {
+        var errors = this.validate();
+        if (errors.isValid()) {
+            var feature = this.getFeature(),
+                protocol = this.getProtocol();
+            if (protocol) {
+               protocol.commit([feature]);
+            } else {
+                feature.layer.events.triggerEvent('featuremodified', {feature: feature});
+            }
+        } else {
+            var message = '';
+            Ext.each(errors.items,function(rec,i){
+                message += rec.getField() + ' ' + rec.getMessage() + "<br>";
+            });
+            Ext.Msg.show({
+                zIndex: 1000,
+                showAnimation: null,
+                hideAnimation: null,
+                message: message,
+                buttons: [{text: 'OK'}],
+                promptConfig: false,
+                fn: function(){}
+            });
+        }
+    },
+    doCancel: function() {
+        // TODO we should use a Feature model/record
+        this.reset();
+        var values = this.getValues(), feature = this.getFeature();
+        for (var name in values) {
+            feature.attributes[name] = values[name];
+        }
+        feature.layer.events.triggerEvent('featuremodified', {feature: feature});
+    },
+    constructor: function (config) {
+        if (config.feature) {
+            this._feature = config.feature;
+            delete config.feature;
+        }
+        this.callParent(arguments);
+    },
+    applyFeature: function (feature) {
+        this.setData({
+            feature: feature
+        });
+        return feature;
+    },
+    initialize: function() {
+        var feature = this.getFeature();
+        // set the given feature in order to call the apply method
+        // which cares about the data types necessary because we do the manual setting
+        // of feature in constructor due to known issues with circular references
+        if (Ext.isDefined(feature)) {
+            this.setFeature(feature);
+        }
+        this.add({
+            xtype: 'toolbar',
+            docked: 'bottom',
+            items: [{
+                xtype: 'spacer',
+                flex: 1
+            }, {
+                text: 'Save',
+                handler: 'doSave',
+                scope: this
+            }, {
+                text: 'Cancel',
+                handler: 'doCancel',
+                scope: this
+            }]
+        });
+        Ext.applyIf(Ext.data.Validations, {
+            range: function(config, value) {
+                return (value === null || (value >= config.minValue && value <= config.maxValue));
+            }
+        });
+        var r = this.self.regexes, fieldCfg, record;
+        var name, fields = [], schema = this.getSchema();
+        var modelConfig = {
+            fields: [],
+            validations: []
+        };
+        if (this.getFormFields()) {
+            for (var i=0, ii=this.getFormFields().length; i<ii; ++i) {
+                name = this.getFormFields()[i];
+                var idx = schema.findExact('name', name);
+                if (idx !== -1) {
+                    record = schema.getAt(idx);
+                    fieldCfg = this.recordToField(record, modelConfig);
+                    if (fieldCfg !== null) {
+                        fields.push(fieldCfg);
+                    }
+                }
+            }
+        } else if (schema) {
+            schema.each(function(record) {
+                var type = record.get("type"); 
+                name = record.get("name");
+                if (type.match(/^[^:]*:?((Multi)?(Point|Line|Polygon|Curve|Surface|Geometry))/)) {
+                    // exclude gml geometries
+                    return;
+                }
+                var fieldCfg = this.recordToField(record, modelConfig);
+                if (fieldCfg !== null) {
+                    fields.push(fieldCfg);
+                }
+            }, this);
+        }
+        this.modelId = Ext.id(null, 'gxm-attribute-model');
+        var model = Ext.define(this.modelId, {
+            extend: 'Ext.data.Model',
+            config: modelConfig
+        });
+        this.setModel(model);
+        this.add(fields);
+        this.callParent();
+    },
+
+    validate: function() {
+        var instance = Ext.create(this.modelId, this.getValues());
+        return instance.validate();
+    },
+
+    onFieldChange: function(field, newValue, oldValue) {
+        var feature = this.getFeature(), name = field.getName();
+        if (!feature.modified) {
+            feature.modified = {
+                attributes: {}
+            };
+        }
+        feature.modified.attributes[name] = true;
+        feature.attributes[name] = newValue;
+        feature.state = OpenLayers.State.UPDATE;
+    },
+
+    recordToField: function(record, modelConfig) {
+        var name = record.get('name');
+        if (this.getExcludeFields() && this.getExcludeFields().indexOf(name) !== -1) {
+            return null;
+        }
+        var options = {};
+        options.listeners = {
+            'change': this.onFieldChange,
+            scope: this
+        };
+        if (this.getReadOnly() === true) {
+            options.readOnly = true;
+        }
+        var feature = this.getFeature();
+        if (feature && feature.attributes[name] !== undefined) {
+            options.value = feature.attributes[name];
+        }
+        var r = this.self.regexes;
+        var type = record.get("type");
+        type = type.split(":").pop();
+        modelConfig.fields.push({name: name, type: type});
+        var fieldConfig = null;
+        options.name = name;
+        var restriction = record.get("restriction") || {};
+        var annotation = record.get('annotation');
+        if (annotation && annotation.appinfo) {
+            options.label = Ext.decode(annotation.appinfo[0]).title[this.getLanguage()];
+        } else {
+            options.label = record.get('name');
+        }
+        if (this.getFieldConfig() && this.getFieldConfig()[name]) {
+            Ext.apply(options, this.getFieldConfig()[name]);
+        }
+        var i, ii;
+        if (annotation && annotation.documentation) {
+            for (i=0, ii=annotation.documentation.length; i<ii; ++i) {
+                if (annotation.documentation[i].lang === this.getLanguage()) {
+                    options.placeHolder = annotation.documentation[i].textContent;
+                    break;
+                }
+            }
+        }
+        if (restriction.enumeration) {
+            var store = [];
+            for (i=0, ii=restriction.enumeration.length; i<ii; ++i) {
+                store.push({text: restriction.enumeration[i], value: restriction.enumeration[i]});
+            }
+            fieldConfig = Ext.apply({
+                xtype: "selectfield",
+                options: store
+            }, options);
+        } else if (type.match(r["text"])) {
+            var minLength = restriction["minLength"] !== undefined ?
+                parseFloat(restriction["minLength"]) : undefined;
+            var maxLength = restriction["maxLength"] !== undefined ?
+                parseFloat(restriction["maxLength"]) : undefined;
+            fieldConfig = Ext.apply({
+                xtype: 'textfield',
+                maxLength: maxLength
+            }, options);
+        } else if (type.match(r["number"])) {
+            var maxValue = restriction["maxInclusive"] !== undefined ?
+                parseFloat(restriction["maxInclusive"]) : undefined;
+            var minValue = restriction["minInclusive"] !== undefined ?
+                parseFloat(restriction["minInclusive"]) : undefined;
+            if (maxValue !== undefined || minValue !== undefined) {
+                modelConfig.validations.push({
+                    field: name,
+                    type: 'range',
+                    message: 'out of range, min: ' + minValue + ', max: ' + maxValue,
+                    minValue: minValue,
+                    maxValue: maxValue
+                });
+            }
+            fieldConfig = Ext.apply({
+                xtype: 'numberfield',
+                minValue: minValue,
+                maxValue: maxValue
+            }, options);
+        } else if (type.match(r["boolean"])) {
+            fieldConfig = Ext.apply({
+                xtype: 'checkboxfield'
+            }, options);
+        } else if (type.match(r["date"])) {
+            fieldConfig = Ext.apply({
+                xtype: 'datepickerfield'
+            }, options);
+        }
+        return fieldConfig;
+    }
+
+});

--- a/src/GXM/form/FeatureEditor.js
+++ b/src/GXM/form/FeatureEditor.js
@@ -15,7 +15,7 @@
  * @class GXM.form.FeatureEditor
  * The class that is used to construct a GXM FeatureEditor. This is a form
  * that can be used to edit the attributes of a feature. The feature itself is 
- * modified and a featuremodified event is trigger on its layer.
+ * modified and a featuremodified event is triggered on its layer.
  * No editing of geometries is currently supported.
  */
 Ext.define("GXM.form.FeatureEditor",{

--- a/tests/lib/FeatureEditor.test.html
+++ b/tests/lib/FeatureEditor.test.html
@@ -28,9 +28,9 @@
         <script type="text/javascript" src="../helperfunctions.js"></script>
         
         <script type="text/javascript">
-        
+
         function test_editor(t) {
-            t.plan(6);
+            t.plan(8);
             var feature = new OpenLayers.Feature.Vector(null, {
                 FILETYPE: "MUNI",
                 SAMP_POP: 7,
@@ -67,14 +67,22 @@
                 var editor = Ext.create("GXM.form.FeatureEditor", {
                     width: 400,
                     height: 400,
+                    fieldConfig: {
+                        MEMO: {label: 'My Memo'}
+                    },
+                    excludeFields: ['STATE_NAME'],
                     centered: true,
                     feature : feature,
                     protocol: protocol,
                     schema: store
                 });
                 var values = editor.getValues();
-                t.eq(values, feature.attributes, "Form values set correctly");
+                var expected = Ext.apply({}, feature.attributes);
+                delete expected['STATE_NAME']; // since it's excluded
+                t.eq(values, expected, "Form values set correctly");
+                t.eq(editor.getFieldsAsArray().length, 6, "6 fields expected since one is excluded");
                 editor.getFields()['SAMP_POP'].getComponent().setValue(15);
+                t.eq(editor.getFields()['MEMO'].getLabel(), "My Memo", "fieldConfig used");
                 t.eq(editor.validate().isValid(), false, 'Form validation taken from the schema');
                 editor.setValues({SAMP_POP: 15});
                 t.eq(editor.getValues()['SAMP_POP'], 10, "Set to max value");

--- a/tests/lib/FeatureEditor.test.html
+++ b/tests/lib/FeatureEditor.test.html
@@ -1,0 +1,93 @@
+<html><head>
+        <title>GXM.FeatureEditor.html</title>
+        <link rel="stylesheet" href="http://cdn.sencha.io/touch/sencha-touch-2.0.1/resources/css/sencha-touch.css" type="text/css">
+        <link rel="stylesheet" href="http://openlayers.org/api/2.11/theme/default/style.css" type="text/css">
+        <link rel="stylesheet" href="../../resources/css/gxm.css" type="text/css">
+        
+        <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
+        <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
+
+        <!-- 
+            Instead of using the Ext.loader-mechanism, we use a very simple 
+            script-loader, which also works in e.g. the iPad and on iOs-Phones.
+        -->
+        <script type="text/javascript">
+        window.LOAD_GXM = [
+            "../../src/GXM/version.js",
+            "../../src/GXM/util/Base.js",
+            "../../src/GXM/form/FeatureEditor.js",
+            "../../src/GXM/data/OwsStore.js",
+            "../../src/GXM/data/reader/Attribute.js",
+            "../../src/GXM/data/AttributeModel.js",
+            "../../src/GXM/data/AttributeStore.js"
+        ];
+        </script>
+        <script type="text/javascript" src="../gxm.scriptloader.js"></script>
+        
+        <!-- load test helper functions -->
+        <script type="text/javascript" src="../helperfunctions.js"></script>
+        
+        <script type="text/javascript">
+        
+        function test_editor(t) {
+            t.plan(6);
+            var feature = new OpenLayers.Feature.Vector(null, {
+                FILETYPE: "MUNI",
+                SAMP_POP: 7,
+                DDRAWDATE: new Date(),
+                MEMO: true,
+                HEIGHT: 728.7,
+                STATE_NAME :'my state',
+                DRINK_NAME: 'pop'
+            });
+            feature.fid = 'foo.1';
+            var layer = new OpenLayers.Layer.Vector(null, {
+                eventListeners: {
+                    "featuremodified": function(evt) {
+                        t.ok(true, "featuremodified triggered on save");
+                    }
+                }
+            });
+            layer.addFeatures([feature]);
+            // dummy protocol
+            var protocol = new OpenLayers.Protocol.WFS({
+                version: '1.1.0',
+                url: '/dummy?',
+                featureType: 'DOCS',
+                featureNS: 'http://www.foo.com/',
+                commit: function(a) {
+                    t.ok(a[0].modified.attributes.SAMP_POP, "modified set on the feature");
+                    t.eq(parseInt(a[0].attributes.SAMP_POP), 10, "transaction called on protocol with the right attributes");
+                }
+            });
+            var store = Ext.create('GXM.data.AttributeStore', {
+                url: "../../examples/data/wfsdescribefeaturetype.xml"
+            });
+            store.on('load', function() {
+                var editor = Ext.create("GXM.form.FeatureEditor", {
+                    width: 400,
+                    height: 400,
+                    centered: true,
+                    feature : feature,
+                    protocol: protocol,
+                    schema: store
+                });
+                var values = editor.getValues();
+                t.eq(values, feature.attributes, "Form values set correctly");
+                editor.getFields()['SAMP_POP'].getComponent().setValue(15);
+                t.eq(editor.validate().isValid(), false, 'Form validation taken from the schema');
+                editor.setValues({SAMP_POP: 15});
+                t.eq(editor.getValues()['SAMP_POP'], 10, "Set to max value");
+                editor.doSave();
+                Ext.destroy(store);
+                Ext.destroy(editor);
+                layer.destroy();
+            });
+            store.load();
+            t.wait_result(1);
+        }
+    </script>
+</head>
+<body></body>
+</html>
+ 

--- a/tests/lib/form/FeatureEditor.test.html
+++ b/tests/lib/form/FeatureEditor.test.html
@@ -2,7 +2,7 @@
         <title>GXM.FeatureEditor.html</title>
         <link rel="stylesheet" href="http://cdn.sencha.io/touch/sencha-touch-2.0.1/resources/css/sencha-touch.css" type="text/css">
         <link rel="stylesheet" href="http://openlayers.org/api/2.11/theme/default/style.css" type="text/css">
-        <link rel="stylesheet" href="../../resources/css/gxm.css" type="text/css">
+        <link rel="stylesheet" href="../../../resources/css/gxm.css" type="text/css">
         
         <script type="text/javascript" src="http://cdn.sencha.io/touch/sencha-touch-2.0.1/sencha-touch-all-debug.js"></script>
         <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
@@ -13,24 +13,24 @@
         -->
         <script type="text/javascript">
         window.LOAD_GXM = [
-            "../../src/GXM/version.js",
-            "../../src/GXM/util/Base.js",
-            "../../src/GXM/form/FeatureEditor.js",
-            "../../src/GXM/data/OwsStore.js",
-            "../../src/GXM/data/reader/Attribute.js",
-            "../../src/GXM/data/AttributeModel.js",
-            "../../src/GXM/data/AttributeStore.js"
+            "../../../src/GXM/version.js",
+            "../../../src/GXM/util/Base.js",
+            "../../../src/GXM/form/FeatureEditor.js",
+            "../../../src/GXM/data/OwsStore.js",
+            "../../../src/GXM/data/reader/Attribute.js",
+            "../../../src/GXM/data/AttributeModel.js",
+            "../../../src/GXM/data/AttributeStore.js"
         ];
         </script>
-        <script type="text/javascript" src="../gxm.scriptloader.js"></script>
+        <script type="text/javascript" src="../../gxm.scriptloader.js"></script>
         
         <!-- load test helper functions -->
-        <script type="text/javascript" src="../helperfunctions.js"></script>
+        <script type="text/javascript" src="../../helperfunctions.js"></script>
         
         <script type="text/javascript">
 
         function test_editor(t) {
-            t.plan(8);
+            t.plan(6);
             var feature = new OpenLayers.Feature.Vector(null, {
                 FILETYPE: "MUNI",
                 SAMP_POP: 7,
@@ -49,19 +49,8 @@
                 }
             });
             layer.addFeatures([feature]);
-            // dummy protocol
-            var protocol = new OpenLayers.Protocol.WFS({
-                version: '1.1.0',
-                url: '/dummy?',
-                featureType: 'DOCS',
-                featureNS: 'http://www.foo.com/',
-                commit: function(a) {
-                    t.ok(a[0].modified.attributes.SAMP_POP, "modified set on the feature");
-                    t.eq(parseInt(a[0].attributes.SAMP_POP), 10, "transaction called on protocol with the right attributes");
-                }
-            });
             var store = Ext.create('GXM.data.AttributeStore', {
-                url: "../../examples/data/wfsdescribefeaturetype.xml"
+                url: "../../../examples/data/wfsdescribefeaturetype.xml"
             });
             store.on('load', function() {
                 var editor = Ext.create("GXM.form.FeatureEditor", {
@@ -73,7 +62,6 @@
                     excludeFields: ['STATE_NAME'],
                     centered: true,
                     feature : feature,
-                    protocol: protocol,
                     schema: store
                 });
                 var values = editor.getValues();
@@ -86,7 +74,7 @@
                 t.eq(editor.validate().isValid(), false, 'Form validation taken from the schema');
                 editor.setValues({SAMP_POP: 15});
                 t.eq(editor.getValues()['SAMP_POP'], 10, "Set to max value");
-                editor.doSave();
+                editor.doUpdate();
                 Ext.destroy(store);
                 Ext.destroy(editor);
                 layer.destroy();
@@ -98,4 +86,3 @@
 </head>
 <body></body>
 </html>
- 

--- a/tests/list-tests.html
+++ b/tests/list-tests.html
@@ -14,5 +14,5 @@
   <li>lib/data/AttributeModel.test.html</li>
   <li>lib/data/AttributeStore.test.html</li>
   <li>lib/data/reader/Attribute.test.html</li>
-  <li>lib/FeatureEditor.test.html</li>
+  <li>lib/form/FeatureEditor.test.html</li>
 </ul>

--- a/tests/list-tests.html
+++ b/tests/list-tests.html
@@ -14,4 +14,5 @@
   <li>lib/data/AttributeModel.test.html</li>
   <li>lib/data/AttributeStore.test.html</li>
   <li>lib/data/reader/Attribute.test.html</li>
+  <li>lib/FeatureEditor.test.html</li>
 </ul>


### PR DESCRIPTION
This component will allow editing of feature attributes. If configured with a WFS protocol, it will allow saving the changes back to the server.

Ideally the commit action would be the responsibility of the FeatureStore, but this was a bridge too far for the purpose of this PR. We should definitely consider changing this in the future though, but it would require more work on the data package first.
