### PR TITLE
make sure an empty feature collection clears the associated store

### DIFF
--- a/src/GXM/data/proxy/Protocol.js
+++ b/src/GXM/data/proxy/Protocol.js
@@ -141,6 +141,10 @@ Ext.define('GXM.data.proxy.Protocol', {
         var callback = o.request.callback;
         if (response.success()) {
             var result = o.reader.read(response.features || response);
+            // an empty array for response.features is a valid response
+            if (response.features && response.features.length === 0) {
+                result.setSuccess(true);
+            }
             if (operation.process('read', result, null, response) === false) {
                 this.fireEvent('exception', this, response, operation);
             }


### PR DESCRIPTION
ProtocolProxy tests still pass in latest Chrome
