### PR TITLE
GXM lists should extend 'Ext.dataview.List' not 'Ext.List'.

### DIFF
--- a/src/GXM/FeatureList.js
+++ b/src/GXM/FeatureList.js
@@ -38,7 +38,7 @@
  */
 Ext.define('GXM.FeatureList', {
 
-    extend: 'Ext.List',
+    extend: 'Ext.dataview.List',
 
     requires: [
         'GXM.version',

--- a/src/GXM/LayerList.js
+++ b/src/GXM/LayerList.js
@@ -37,7 +37,7 @@
  *      };
  */
 Ext.define('GXM.LayerList', {
-    extend: 'Ext.List',
+    extend: 'Ext.dataview.List',
     requires: [
         'GXM.version',
         'GXM.util.Base',


### PR DESCRIPTION
`Ext.List`, which was previously used, is an alias for `Ext.dataview.List`. When
using the autoloading mechanism of Sencha Touch, this wouldn't correctly load
the required files for extension.

Please review.
